### PR TITLE
Remove adm-zip dependency from tests and use native zip command to preserve file permission on binaries

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -128,10 +128,23 @@ Lambda.prototype._zip = function(program, codeDirectory, callback) {
       zip.file(file, content);
     }
   });
-  
+
   var data = zip.generate(options);
 
   return callback(null, data);
+};
+
+Lambda.prototype._nativeZip = function(program, codeDirectory, callback) {
+  var zipfile = this._zipfileTmpPath(program)
+    , cmd = 'zip -r ' + zipfile + ' .'
+    , run = exec(cmd, { cwd: codeDirectory }, function (err, stdout, stderr) {
+        if (err !== null) {
+          return callback(err, null)
+        }
+
+        var data = fs.readFileSync(zipfile)
+        callback(null, data)
+    })
 };
 
 Lambda.prototype._codeDirectory = function(program) {
@@ -149,7 +162,11 @@ Lambda.prototype.deploy = function(program) {
   // Move all files to tmp folder (except .git, .log, event.json and node_modules)
   _this._rsync(program, codeDirectory, function(err, result) {
     _this._npmInstall(program, codeDirectory, function(err, result) {
-      _this._zip(program, codeDirectory, function(err, buffer) {
+      // Use zip from the command line on non-windows systems to preserve file permissions
+      var archive = process.platform != 'win32' ? _this._nativeZip : _this._zip;
+      archive = archive.bind(_this)
+
+      archive(program, codeDirectory, function(err, buffer) {
 
         console.log('Reading zip file to memory');
         //var buffer = fs.readFileSync(zipfile);

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "author": "motdotla",
   "license": "BSD",
   "devDependencies": {
-    "adm-zip": "^0.4.7",
     "chai": "^2.0.0",
     "hoek": "^2.11.1",
     "lodash": "^3.2.0",

--- a/test/main.js
+++ b/test/main.js
@@ -6,7 +6,7 @@ var lambda = require('../lib/main');
 var os = require('os');
 var fs = require('fs');
 var _ = require('lodash');
-var admzip = require('adm-zip');
+var zip = require('node-zip');
 
 var assert = chai.assert;
 
@@ -111,10 +111,9 @@ describe('node-lambda', function() {
     it('zips the file and has an index.js file', function(done) {
       this.timeout(30000); // give it time to zip
 
-      lambda._zip(program, codeDirectory, function(err, zipfilePath) {
-        var zip = new admzip(zipfilePath);
-        var zipEntries = zip.getEntries();
-        var contents = _.map(zipEntries, function(entry) { return entry.entryName.toString() });
+      lambda._zip(program, codeDirectory, function(err, data) {
+        var archive = new zip(data);
+        var contents = _.map(archive.files, function(f) { return f.name.toString() });
         var result = _.includes(contents, 'index.js');
         assert.equal(result, true);
 


### PR DESCRIPTION
Using the same node-zip package as the actual app