### PR TITLE
Increasing buffer size to allow for zip files of up to 10MB

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -142,8 +142,10 @@ Lambda.prototype._zip = function (program, codeDirectory, callback) {
 Lambda.prototype._nativeZip = function (program, codeDirectory, callback) {
   var zipfile = this._zipfileTmpPath(program),
     cmd = 'zip -r ' + zipfile + ' .';
+
   exec(cmd, {
-    cwd: codeDirectory
+    cwd: codeDirectory,
+    maxBuffer: 10 * 1024 * 1024
   }, function (err) {
     if (err !== null) {
       return callback(err, null);


### PR DESCRIPTION
node-lambda was failing for me if the size of the returned zip was 512K, this solves that.