### PR TITLE
Increased size of zip buffer.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -145,7 +145,7 @@ Lambda.prototype._nativeZip = function (program, codeDirectory, callback) {
 
   exec(cmd, {
     cwd: codeDirectory,
-    maxBuffer: 10 * 1024 * 1024
+    maxBuffer: 50 * 1024 * 1024
   }, function (err) {
     if (err !== null) {
       return callback(err, null);


### PR DESCRIPTION
Hi,

As discussed in #25, AWS Lambda supports uploading zip sizes of up to 50MB \[[1](http://docs.aws.amazon.com/lambda/latest/dg/limits.html)\] so it makes sense to
support zip files of up to that size with node-lambda.

Cheers & thanks again for your work :)

Darian